### PR TITLE
Add missing compromise dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "homepage": "https://github.com/01tek/ai-thing#readme",
   "devDependencies": {
     "jest": "^29.7.0"
+  },
+  "dependencies": {
+    "compromise": "^14.14.0"
   }
 }


### PR DESCRIPTION
Couldn't start the test suite because of missing dependencies.